### PR TITLE
BigInt 지원, Int64 제거

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @greenlabs/rescript-korean-numeral
 
+## 0.4.0
+
+### Breaking Changes
+
+- ReScript v11.1 BigInt 지원
+- fromInt64 API 제거
+- fromString 함수의 반환 타입 변경: `string` -> `option<string>`
+
+## 0.3.0
+
+- ReScript v11 지원
+
 ## 0.2.0
 
 ### Minor Changes

--- a/__tests__/KoreanNumeral_test.res
+++ b/__tests__/KoreanNumeral_test.res
@@ -4,15 +4,15 @@ describe(`1만 이하 표시`, () => {
   open Expect
 
   test(`KoreanNumeral.fromInt`, () => {
-    let result = KoreanNumeral.fromInt(1234, ())
+    let result = KoreanNumeral.fromInt(1234)
     expect(result)->toBe(`1,234`)
   })
   test(`KoreanNumeral.fromFloat`, () => {
-    let result = KoreanNumeral.fromFloat(152212525110.0, ())
+    let result = KoreanNumeral.fromFloat(152212525110.0)
     expect(result)->toBe(`1,522억 1,252만 5,110`)
   })
-  test(`KoreanNumeral.fromInt64`, () => {
-    let result = KoreanNumeral.fromInt64(Int64.of_string("1234567890987654321"), ())
+  test(`KoreanNumeral.fromBigInt`, () => {
+    let result = KoreanNumeral.fromBigInt(1234567890987654321n)
     expect(result)->toBe(`123경 4,567조 8,909억 8,765만 4,321`)
   })
 })
@@ -21,35 +21,51 @@ describe(`1만 이하는 절삭`, () => {
   open Expect
 
   test(`1234 => ""`, () => {
-    let result = KoreanNumeral.fromInt(1234, ~drop=1, ())
+    let result = KoreanNumeral.fromInt(1234, ~drop=1)
     expect(result)->toBe(``)
   })
   test(`1234567 => "123만"`, () => {
-    let result = KoreanNumeral.fromInt(1234567, ~drop=1, ())
+    let result = KoreanNumeral.fromInt(1234567, ~drop=1)
     expect(result)->toBe(`123만`)
   })
   test(`1234567890 => "12억 3,456만"`, () => {
-    let result = KoreanNumeral.fromInt(1234567890, ~drop=1, ())
+    let result = KoreanNumeral.fromInt(1234567890, ~drop=1)
     expect(result)->toBe(`12억 3,456만`)
   })
   test(`1234567890.1 => "12억 3,456만"`, () => {
-    let result = KoreanNumeral.fromFloat(1234567890.1, ~drop=1, ())
+    let result = KoreanNumeral.fromFloat(1234567890.1, ~drop=1)
     expect(result)->toBe(`12억 3,456만`)
   })
   test(`152212525110 => "1,522억 1,252만"`, () => {
-    let result = KoreanNumeral.fromFloat(152212525110.0, ~drop=1, ())
+    let result = KoreanNumeral.fromFloat(152212525110.0, ~drop=1)
     expect(result)->toBe(`1,522억 1,252만`)
   })
   test(`152212525110 => "1,522억"`, () => {
-    let result = KoreanNumeral.fromFloat(152200005110.0, ~drop=1, ())
+    let result = KoreanNumeral.fromFloat(152200005110.0, ~drop=1)
     expect(result)->toBe(`1,522억`)
   })
   test(`220000152212525110.0 => "22경 1,522억 1,252만"`, () => {
-    let result = KoreanNumeral.fromFloat(220000152212525110.0, ~drop=1, ())
+    let result = KoreanNumeral.fromFloat(220000152212525110.0, ~drop=1)
     expect(result)->toBe(`22경 1,522억 1,252만`)
   })
   test(`1234567890987654321 => "123경 4,567조 8,909억 8,765만"`, () => {
-    let result = KoreanNumeral.fromString("1234567890987654321", ~drop=1, ())
+    let result = KoreanNumeral.fromString("1234567890987654321a", ~drop=1)
+    expect(result)->toBe(None)
+  })
+  test(`152212525110n => "1,522억 1,252만"`, () => {
+    let result = KoreanNumeral.fromBigInt(152212525110n, ~drop=1)
+    expect(result)->toBe(`1,522억 1,252만`)
+  })
+  test(`152212525110n => "1,522억"`, () => {
+    let result = KoreanNumeral.fromBigInt(152200005110n, ~drop=1)
+    expect(result)->toBe(`1,522억`)
+  })
+  test(`220000152212525110n => "22경 1,522억 1,252만"`, () => {
+    let result = KoreanNumeral.fromBigInt(220000152212525110n, ~drop=1)
+    expect(result)->toBe(`22경 1,522억 1,252만`)
+  })
+  test(`1234567890987654321n => "123경 4,567조 8,909억 8,765만"`, () => {
+    let result = KoreanNumeral.fromBigInt(1234567890987654321n, ~drop=1)
     expect(result)->toBe(`123경 4,567조 8,909억 8,765만`)
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@greenlabs/rescript-korean-numeral",
-  "version": "0.3.0",
+  "packageManager": "pnpm@8.8.0",
+  "version": "0.4.0",
   "description": "ReScript module to convert the number to Korean",
   "scripts": {
     "start": "rescript build -w",
@@ -26,6 +27,6 @@
   "devDependencies": {
     "@glennsl/rescript-jest": "^0.10.0",
     "jest": "^29.7.0",
-    "rescript": "^11"
+    "rescript": "11.1.0-rc.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ devDependencies:
     specifier: ^29.7.0
     version: 29.7.0
   rescript:
-    specifier: ^11
-    version: 11.0.1
+    specifier: 11.1.0-rc.6
+    version: 11.1.0-rc.6
 
 packages:
 
@@ -3007,8 +3007,8 @@ packages:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
     dev: true
 
-  /rescript@11.0.1:
-    resolution: {integrity: sha512-7T4PRp/d0+CBNnY6PYKffFqo9tGZlvnZpboF/n+8SKS+JZ6VvXJO7W538VPZXf3EYx1COGAWWvkF9e/HgSAqHg==}
+  /rescript@11.1.0-rc.6:
+    resolution: {integrity: sha512-chaNkU5xvWC+NOKflmNiQDMj8wu1Vk+SX9vUH84m9gT9cGE49ml1rG25XUPlKQ4EJ+AR+0XYLfxxvzjKYC+qvQ==}
     engines: {node: '>=10'}
     hasBin: true
     requiresBuild: true


### PR DESCRIPTION
- ReScript v11.1 BigInt 지원
- fromInt64 API 제거
- fromString 함수의 반환 타입 변경: `string` -> `option<string>`